### PR TITLE
Made SenderIds non-static and raised visibility to protected.

### DIFF
--- a/Gcm.Client/GcmServiceBase.cs
+++ b/Gcm.Client/GcmServiceBase.cs
@@ -22,7 +22,10 @@ namespace Gcm.Client
 		static object LOCK = new object();
 		static int serviceId = 1;
 
-		static string[] SenderIds = new string[] {};
+        /// <summary>
+        /// The GCM Sender Ids to use. Set by the constructor taking parameters but not by the one that doesn't. Be very careful changing this value, preferably only set it in your constructor and only once.
+        /// </summary>
+		protected string[] SenderIds = new string[] {};
 
 		//int sCounter = 1;
 		Random sRandom = new Random();


### PR DESCRIPTION
This will allow sub-classes to set this value dynamically in the constructor. This should be done with care however.

I needed this as I'm using it for a template on which many Apps will be made. I can't hard code the sender id as that would require my building process to parse and modify C# code, instead I need to read it from an XML in the APK and set it.